### PR TITLE
Avoid setting app config variables as module attributes at compile time

### DIFF
--- a/lib/itk/queue/connection.ex
+++ b/lib/itk/queue/connection.ex
@@ -5,7 +5,6 @@ defmodule ITKQueue.Connection do
 
   use GenServer
 
-  @url Application.get_env(:itk_queue, :amqp_url)
   @name :itk_queue_connection
 
   @doc false
@@ -41,7 +40,7 @@ defmodule ITKQueue.Connection do
 
   @spec do_connect() :: AMQP.Connection.t
   defp do_connect do
-    case AMQP.Connection.open(@url) do
+    case AMQP.Connection.open(amqp_url()) do
       {:ok, connection} ->
         Process.monitor(connection.pid)
         connection
@@ -49,5 +48,9 @@ defmodule ITKQueue.Connection do
         Process.sleep(1000)
         connect()
     end
+  end
+
+  defp amqp_url do
+    Application.get_env(:itk_queue, :amqp_url)
   end
 end

--- a/lib/itk/queue/fallback.ex
+++ b/lib/itk/queue/fallback.ex
@@ -1,13 +1,9 @@
 defmodule ITKQueue.Fallback do
   @moduledoc false
 
-  @endpoint Application.get_env(:itk_queue, :fallback_endpoint)
-  @username Application.get_env(:itk_queue, :fallback_username)
-  @password Application.get_env(:itk_queue, :fallback_password)
-
   @spec publish(routing_key :: String.t, message :: Map.t) :: no_return
   def publish(routing_key, message) do
-    do_publish(@endpoint, routing_key, message)
+    do_publish(endpoint(), routing_key, message)
   end
 
   defp do_publish(false, _, _), do: nil
@@ -19,9 +15,21 @@ defmodule ITKQueue.Fallback do
   end
 
   defp publish_options do
-    case [@username, @password] do
+    case [username(), password()] do
       [nil, nil] -> []
       [username, password] -> [hackney: [basic_auth: {username, password}]]
     end
+  end
+
+  defp endpoint do
+    Application.get_env(:itk_queue, :fallback_endpoint)
+  end
+
+  defp username do
+    Application.get_env(:itk_queue, :fallback_username)
+  end
+
+  defp password do
+    Application.get_env(:itk_queue, :fallback_password)
   end
 end


### PR DESCRIPTION
Module attributes were being set at compilation time from the application
configuration. This is normally not a problem when done within an app,
because mix triggers a full app recompile if a config file changes.

For dependencies, mix does not attempt to rebuild dependencies when the
config file changes if it has already been compiled.