### PR TITLE
Ability to declare queue and pass options during message publish

### DIFF
--- a/lib/itk/queue/channel.ex
+++ b/lib/itk/queue/channel.ex
@@ -11,7 +11,7 @@ defmodule ITKQueue.Channel do
   @spec open(connection :: AMQP.Connection.t()) :: AMQP.Channel.t()
   def open(connection) do
     {:ok, channel} = AMQP.Channel.open(connection)
-    AMQP.Exchange.topic(channel, exchange())
+    AMQP.Exchange.topic(channel, default_exchange())
     channel
   end
 
@@ -29,20 +29,61 @@ defmodule ITKQueue.Channel do
 
   Returns the given `AMQP.Channel`.
   """
-  @spec bind(channel :: AMQP.Channel.t(), queue_name :: String.t(), routing_key :: String.t()) ::
+  @spec bind(channel :: AMQP.Channel.t(), queue_name :: String.t(), routing_key :: String.t(), options :: Keyword.t()) ::
           AMQP.Channel.t()
-  def bind(channel, queue_name, routing_key) do
-    AMQP.Basic.qos(channel, prefetch_count: consumer_count())
-    AMQP.Queue.declare(channel, queue_name, durable: true, auto_delete: false)
-    AMQP.Queue.bind(channel, queue_name, exchange(), routing_key: routing_key)
+  def bind(channel, queue_name, routing_key, options \\ []) do
+    unless ITKQueue.testing?() do
+      exchange = options |> bind_options() |> Keyword.get(:exchange)
+
+      declare_queue(channel, queue_name, declare_options(options))
+      AMQP.Basic.qos(channel, prefetch_count: consumer_count())
+      AMQP.Queue.bind(channel, queue_name, exchange, routing_key: routing_key)
+    end
+
     channel
   end
 
-  defp exchange do
+  @doc """
+  Declares a queue.
+  """
+  @spec declare_queue(channel :: AMQP.Channel.t(), queue_name :: String.t(), options :: Keyword.t()) :: AMQP.Channel.t()
+  def declare_queue(channel, queue_name, options \\ []) do
+    unless ITKQueue.testing?() do
+      {:ok, _} = AMQP.Queue.declare(channel, queue_name, declare_options(options))
+    end
+
+    channel
+  end
+
+  @doc """
+  Deletes a queue.
+  """
+  @spec delete_queue(channel :: AMQP.Channel.t(), queue_name :: String.t()) :: AMQP.Channel.t()
+  def delete_queue(channel, queue_name) do
+    unless ITKQueue.testing?() do
+      {:ok, _} = AMQP.Queue.delete(channel, queue_name)
+    end
+
+    channel
+  end
+
+  defp default_exchange do
     Application.get_env(:itk_queue, :amqp_exchange)
   end
 
   defp consumer_count do
     Application.get_env(:itk_queue, :consumer_count, 10)
+  end
+
+  defp bind_options(options) do
+    options
+    |> Keyword.put_new(:exchange, default_exchange())
+  end
+
+  defp declare_options(options) do
+    options
+    |> Keyword.put_new(:arguments, [])
+    |> Keyword.put_new(:auto_delete, false)
+    |> Keyword.put_new(:durable, true)
   end
 end

--- a/lib/itk/queue/retry.ex
+++ b/lib/itk/queue/retry.ex
@@ -45,7 +45,7 @@ defmodule ITKQueue.Retry do
       )
 
     :ok = AMQP.Queue.bind(channel, queue_name, exchange(), routing_key: queue_name)
-    Publisher.publish(queue_name, message, headers)
+    Publisher.publish(queue_name, message, headers, [])
   end
 
   @spec count(Headers.t()) :: non_neg_integer


### PR DESCRIPTION
* Adds support for creating and deleting queues without binding the queue to an exchange.
* Adds an `options` argument to each of the publish functions in `ITKQueue.Publisher` that gets passed to `AMQP.Basic.publish`.  This is a breaking change for anyone using that module directly, but the expectation has been to mostly go through the `ITKQueue.publish` function instead.