### PR TITLE
Update to using application env vars instead of Mix.env

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -4,4 +4,5 @@ config :itk_queue,
   amqp_url: "amqp://localhost:5672",
   amqp_exchange: "development",
   fallback_endpoint: false,
-  max_retries: 10
+  max_retries: 10,
+  env: Mix.env()

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :itk_queue,
+  env: Mix.env()

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,4 +5,5 @@ config :itk_queue,
   amqp_exchange: "test",
   fallback_endpoint: false,
   running_library_tests: true,
-  max_retries: 10
+  max_retries: 10,
+  env: Mix.env()

--- a/lib/itk/queue.ex
+++ b/lib/itk/queue.ex
@@ -13,9 +13,13 @@ defmodule ITKQueue do
   def start(_type, _args) do
     opts = [strategy: :one_for_one, name: ITKQueue.Supervisor]
 
-    Mix.env()
+    environment()
     |> children
     |> Supervisor.start_link(opts)
+  end
+
+  defp environment() do
+    Application.get_env(:itk_queue, :env)
   end
 
   defp children(:test) do
@@ -64,7 +68,7 @@ defmodule ITKQueue do
           handler :: (any(), any() -> any())
         ) :: {:ok, pid}
   def subscribe(queue_name, routing_key, handler) when is_function(handler, 2) do
-    if Mix.env() == :test && !running_library_tests?() do
+    if environment() == :test && !running_library_tests?() do
       {:ok, :ok}
     else
       handler =
@@ -132,7 +136,7 @@ defmodule ITKQueue do
 
   @doc false
   def testing? do
-    Mix.env() == :test && !running_library_tests?()
+    environment() == :test && !running_library_tests?()
   end
 
   @doc false

--- a/lib/itk/queue/channel.ex
+++ b/lib/itk/queue/channel.ex
@@ -121,6 +121,7 @@ defmodule ITKQueue.Channel do
 
   @spec testing?() :: boolean
   defp testing? do
-    Mix.env() == :test && !Application.get_env(:itk_queue, :running_library_tests, false)
+    Application.get_env(:itk_queue, :env) == :test &&
+      !Application.get_env(:itk_queue, :running_library_tests, false)
   end
 end

--- a/lib/itk/queue/connection_pool.ex
+++ b/lib/itk/queue/connection_pool.ex
@@ -83,7 +83,7 @@ defmodule ITKQueue.ConnectionPool do
     ITKQueue.ConnectionPool.checkin(ref)
   """
   def checkout do
-    if Mix.env() == :test && !running_library_tests?() do
+    if Application.get_env(:itk_queue, :env) == :test && !running_library_tests?() do
       {self(), %AMQP.Connection{}}
     else
       pid = :poolboy.checkout(@pool_name)
@@ -96,7 +96,7 @@ defmodule ITKQueue.ConnectionPool do
   Return a connection to the pool.
   """
   def checkin(pid) do
-    unless Mix.env() == :test && !running_library_tests?() do
+    unless Application.get_env(:itk_queue, :env) == :test && !running_library_tests?() do
       :poolboy.checkin(@pool_name, pid)
     end
   end

--- a/lib/itk/queue/publisher.ex
+++ b/lib/itk/queue/publisher.ex
@@ -284,7 +284,8 @@ defmodule ITKQueue.Publisher do
 
   @spec testing?() :: boolean
   defp testing? do
-    Mix.env() == :test && !Application.get_env(:itk_queue, :running_library_tests, false)
+    Application.get_env(:itk_queue, :env) == :test &&
+      !Application.get_env(:itk_queue, :running_library_tests, false)
   end
 
   defp fake_publish(routing_key, message) do

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule ITKQueue.Mixfile do
     [
       app: :itk_queue,
       version: @version,
-      elixir: "~> 1.7",
+      elixir: "~> 1.6",
       description:
         "Provides convenience methods for subscribing to queues and publishing messages.",
       source_url: @project_url,

--- a/mix.exs
+++ b/mix.exs
@@ -2,13 +2,13 @@ defmodule ITKQueue.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/inside-track/itk_queue"
-  @version "0.9.9"
+  @version "0.10.0"
 
   def project do
     [
       app: :itk_queue,
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       description:
         "Provides convenience methods for subscribing to queues and publishing messages.",
       source_url: @project_url,
@@ -43,7 +43,7 @@ defmodule ITKQueue.Mixfile do
 
   defp package do
     [
-      maintainers: ["Adam Vaughan", "Grant Austin", "Daniel Hedlund"],
+      maintainers: ["Adam Vaughan", "Grant Austin", "Jared Smith"],
       licenses: ["MIT"],
       links: %{
         "GitHub" => @project_url


### PR DESCRIPTION
Updating runtime code to use application env vars instead of mix.env this is a change to allow distillery 2.0 releases since Mix.env will no longer be available during runtime or application boot-time.