### PR TITLE
Asynchronously consume messages.

### DIFF
--- a/lib/itk/queue/consumer.ex
+++ b/lib/itk/queue/consumer.ex
@@ -41,7 +41,7 @@ defmodule ITKQueue.Consumer do
         {:basic_deliver, payload, meta},
         state = %{channel: channel, subscription: subscription}
       ) do
-    consume(channel, meta, payload, subscription)
+    consume_async(channel, meta, payload, subscription)
     {:noreply, state}
   end
 
@@ -82,6 +82,12 @@ defmodule ITKQueue.Consumer do
 
       {:ok, _} = AMQP.Basic.consume(channel, queue_name, self())
       {:ok, %{channel: channel, subscription: subscription}}
+    end)
+  end
+
+  defp consume_async(channel, meta, payload, subscription) do
+    spawn(fn ->
+      consume(channel, meta, payload, subscription)
     end)
   end
 


### PR DESCRIPTION
We can control how many unacked messages rabbit will send us by changing the `consumer_count` configuration but the code still processed those messages serially. This change spawns a new process for each message we receive.

This has a pretty considerable impact on the speeed with which we can process messages. We may need to keep an eye out for database connection depletion issues though. I think the worst that will happen is we get a timeout when trying to get a connection from the connection pool and the message will be requeued and retried.