### PR TITLE
Share a persistent connection between all queue subscribers.

### DIFF
--- a/lib/itk/queue.ex
+++ b/lib/itk/queue.ex
@@ -33,12 +33,10 @@ defmodule ITKQueue do
   defp children(_), do: children()
 
   defp children do
-    import Supervisor.Spec
-
     [
-      worker(ITKQueue.ConnectionPool, []),
-      supervisor(ITKQueue.ConsumerSupervisor, []),
-      worker(ITKQueue.Workers, [])
+      ITKQueue.ConnectionPool,
+      ITKQueue.ConsumerSupervisor,
+      ITKQueue.Workers
     ]
   end
 

--- a/lib/itk/queue/connection.ex
+++ b/lib/itk/queue/connection.ex
@@ -6,6 +6,11 @@ defmodule ITKQueue.Connection do
   """
 
   @doc false
+  def start_link(opts, name) do
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc false
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts)
   end

--- a/lib/itk/queue/connection_pool.ex
+++ b/lib/itk/queue/connection_pool.ex
@@ -13,13 +13,13 @@ defmodule ITKQueue.ConnectionPool do
   @pool_name :amqp_pool
 
   @doc false
-  def start_link do
-    Supervisor.start_link(__MODULE__, :ok)
+  def start_link(arg) do
+    Supervisor.start_link(__MODULE__, arg)
   end
 
   @doc false
-  @spec init(:ok) :: no_return
-  def init(:ok) do
+  @spec init(term) :: no_return
+  def init(_arg) do
     pool_opts = [
       name: {:local, @pool_name},
       worker_module: Connection,

--- a/lib/itk/queue/consumer.ex
+++ b/lib/itk/queue/consumer.ex
@@ -13,11 +13,11 @@ defmodule ITKQueue.Consumer do
 
   @doc false
   def start_link(subscription = %Subscription{}) do
-    GenServer.start_link(__MODULE__, subscription, [])
+    GenServer.start_link(__MODULE__, subscription, name: {:global, subscription.queue_name})
   end
 
   @doc false
-  def init(subscription) do
+  def init(subscription = %Subscription{}) do
     subscribe(subscription)
   end
 

--- a/lib/itk/queue/consumer_supervisor.ex
+++ b/lib/itk/queue/consumer_supervisor.ex
@@ -1,24 +1,18 @@
 defmodule ITKQueue.ConsumerSupervisor do
   @moduledoc false
 
-  use Supervisor
+  use DynamicSupervisor
 
   alias ITKQueue.{Consumer, Subscription}
 
-  @name :itk_queue_consumer_supervisor
-
   @doc false
-  def start_link do
-    Supervisor.start_link(__MODULE__, :ok, name: @name)
+  def start_link() do
+    DynamicSupervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
   @doc false
   def init(:ok) do
-    children = [
-      worker(Consumer, [], restart: :permanent)
-    ]
-
-    supervise(children, strategy: :simple_one_for_one)
+    DynamicSupervisor.init(strategy: :one_for_one)
   end
 
   @doc """
@@ -26,6 +20,10 @@ defmodule ITKQueue.ConsumerSupervisor do
   """
   @spec start_consumer(subscription :: Subscription.t()) :: {:ok, pid}
   def start_consumer(subscription = %Subscription{}) do
-    Supervisor.start_child(@name, [subscription])
+    DynamicSupervisor.start_child(__MODULE__, %{
+      id: "#{subscription.queue_name}_consumer",
+      start: {Consumer, :start_link, [subscription]},
+      restart: :transient
+    })
   end
 end

--- a/lib/itk/queue/consumer_supervisor.ex
+++ b/lib/itk/queue/consumer_supervisor.ex
@@ -6,12 +6,12 @@ defmodule ITKQueue.ConsumerSupervisor do
   alias ITKQueue.{Consumer, Subscription}
 
   @doc false
-  def start_link() do
-    DynamicSupervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+  def start_link(arg) do
+    DynamicSupervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
 
   @doc false
-  def init(:ok) do
+  def init(_arg) do
     DynamicSupervisor.init(strategy: :one_for_one)
   end
 

--- a/lib/itk/queue/workers.ex
+++ b/lib/itk/queue/workers.ex
@@ -4,12 +4,12 @@ defmodule ITKQueue.Workers do
   use GenServer
 
   @doc false
-  def start_link do
-    GenServer.start_link(__MODULE__, :ok, [])
+  def start_link(arg) do
+    GenServer.start_link(__MODULE__, arg, [])
   end
 
   @doc false
-  def init(:ok) do
+  def init(_arg) do
     if start_workers?() do
       Process.send_after(self(), :start_workers, 5000)
     end


### PR DESCRIPTION
Since queue subscriptions require a persistent connection, this change uses
a separate connection instead of reusing one from the connection pool. This
circumvents the issue we've seen where we resubscribe on an overflow
connection that is closed after it is returned to the pool. By having the
supervisor manage this connection we can employ the `rest_for_one` strategy
so that if the connection dies all workers will be killed as well and then
restarted after the connection restarts.