### PR TITLE
Set heartbeat to 10 by default

### DIFF
--- a/lib/itk/queue/connection_pool.ex
+++ b/lib/itk/queue/connection_pool.ex
@@ -118,7 +118,7 @@ defmodule ITKQueue.ConnectionPool do
   end
 
   defp heartbeat do
-    Application.get_env(:itk_queue, :heartbeat, 60)
+    Application.get_env(:itk_queue, :heartbeat, 10)
   end
 
   defp running_library_tests? do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ITKQueue.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/inside-track/itk_queue"
-  @version "0.10.10"
+  @version "0.10.11"
 
   def project do
     [


### PR DESCRIPTION
It's been tested in staging-k8s env that 10 eliminates socket_closed error logs. Version is incremented to 0.10.11.