### PR TITLE
Fix duplicate config getter

### DIFF
--- a/lib/itk/queue.ex
+++ b/lib/itk/queue.ex
@@ -163,11 +163,11 @@ defmodule ITKQueue do
     :ok
   end
 
-  defp amqp_url do
+  def amqp_url do
     Application.get_env(:itk_queue, :amqp_url, "amqp://localhost:5672")
   end
 
-  defp heartbeat do
-    Application.get_env(:itk_queue, :heartbeat, 60)
+  def heartbeat do
+    Application.get_env(:itk_queue, :heartbeat, 10)
   end
 end

--- a/lib/itk/queue/connection_pool.ex
+++ b/lib/itk/queue/connection_pool.ex
@@ -29,8 +29,8 @@ defmodule ITKQueue.ConnectionPool do
 
     children = [
       :poolboy.child_spec(@pool_name, pool_opts,
-        amqp_url: amqp_url(),
-        heartbeat: heartbeat(),
+        amqp_url: ITKQueue.amqp_url(),
+        heartbeat: ITKQueue.heartbeat(),
         reconnect: true
       )
     ]
@@ -111,14 +111,6 @@ defmodule ITKQueue.ConnectionPool do
 
   def max_overflow do
     Application.get_env(:itk_queue, :max_overflow, pool_size() * 3)
-  end
-
-  defp amqp_url do
-    Application.get_env(:itk_queue, :amqp_url, "amqp://localhost:5672")
-  end
-
-  defp heartbeat do
-    Application.get_env(:itk_queue, :heartbeat, 10)
   end
 
   defp running_library_tests? do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ITKQueue.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/inside-track/itk_queue"
-  @version "0.10.11"
+  @version "0.10.12"
 
   def project do
     [


### PR DESCRIPTION
There was exactly the same code in `ITKQueue` and `ITKQueue.ConnectionPool` modules to get amqp connection URL and heartbeat. I refactored to keep them in `ITKQueue`.