### PR TITLE
[Lager] Silent crash logs by lager and prevent its logs to file

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -10,4 +10,5 @@ config :itk_queue,
 # silent amqp rabbit_common logging
 config :lager,
   error_logger_redirect: true,
+  crash_log: false,
   handlers: [level: :critical]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -6,4 +6,5 @@ config :itk_queue,
 # silent amqp rabbit_common logging
 config :lager,
   error_logger_redirect: false,
+  crash_log: false,
   handlers: [level: :critical]

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,3 +7,9 @@ config :itk_queue,
   running_library_tests: true,
   max_retries: 10,
   env: Mix.env()
+
+# silent amqp rabbit_common logging
+config :lager,
+  error_logger_redirect: true,
+  crash_log: false,
+  handlers: [level: :critical]


### PR DESCRIPTION
**Description:**
- ITK-QUEUE now runs as a dependency for lots of other services, introducing `lager` dep into it caused all runs (test/dev/...) to create a `log/` folder where it creates multiple files for the logging data (info, error, ...).
- Looking at https://github.com/basho/lager#configuration, I could only figure out how to disable crash logs from going into a file instead of console.

**Testing:**
- Ran `mix test`, before it was creating a log/ folder, now nothing is created.
- Same for dev, ran `iex -S mix`, no log folder is created