### PR TITLE
Propagate exception on retry_or_die to QueueErrorHandler

### DIFF
--- a/lib/itk/queue/consumer.ex
+++ b/lib/itk/queue/consumer.ex
@@ -271,6 +271,10 @@ defmodule ITKQueue.Consumer do
     if should_retry?(headers) do
       retry(message, channel, meta, subscription, reason)
     else
+      error_handler().handle(queue_name, routing_key, Jason.encode!(message), %RuntimeError{
+        message: reason
+      })
+
       reject(message, channel, meta, subscription, reason)
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ITKQueue.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/inside-track/itk_queue"
-  @version "0.10.13"
+  @version "0.10.14"
 
   def project do
     [


### PR DESCRIPTION
**Description:**

Some flow in itk_queue message consumption caused lots of exceptions to arise without a notice in Sentry. Looking at the flow it seems that the `QueueErrorHandler` module in every microservice is set to handle the corresponding error propagation. Adding a missing one.

![Screen Shot 2019-11-03 at 7 17 05 PM](https://user-images.githubusercontent.com/1479894/68089159-adf6c880-fe6e-11e9-8478-faaa629dbd9b.png)
