### PR TITLE
Publisher pool for fast publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The package can be installed by adding `itk_queue` to your list of dependencies 
 
 ```elixir
 def deps do
-  [{:itk_queue, "~> 0.10.13"}]
+  [{:itk_queue, "~> 0.11.0"}]
 end
 ```
 

--- a/lib/itk/queue.ex
+++ b/lib/itk/queue.ex
@@ -35,6 +35,7 @@ defmodule ITKQueue do
   defp children do
     [
       ITKQueue.ConnectionPool,
+      ITKQueue.PublisherPool,
       %{
         id: ITKQueue.ConsumerConnection,
         start:

--- a/lib/itk/queue/connection_pool.ex
+++ b/lib/itk/queue/connection_pool.ex
@@ -24,7 +24,7 @@ defmodule ITKQueue.ConnectionPool do
       name: {:local, @pool_name},
       worker_module: Connection,
       size: pool_size(),
-      max_overflow: max_overflow()
+      max_overflow: 0
     ]
 
     children = [
@@ -107,10 +107,6 @@ defmodule ITKQueue.ConnectionPool do
 
   defp pool_size do
     Application.get_env(:itk_queue, :pool_size, 10)
-  end
-
-  def max_overflow do
-    Application.get_env(:itk_queue, :max_overflow, pool_size() * 3)
   end
 
   defp running_library_tests? do

--- a/lib/itk/queue/pub_channel.ex
+++ b/lib/itk/queue/pub_channel.ex
@@ -1,0 +1,59 @@
+defmodule ITKQueue.PubChannel do
+  @moduledoc """
+  Worker for pooled publishers to AMQP message queue.
+  """
+
+  use GenServer
+  use AMQP
+  require Logger
+
+  @reconnect_interval 1000
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args)
+  end
+
+  def init(_) do
+    Process.flag(:trap_exit, true)
+    send(self(), :connect)
+    {:ok, %{status: :disconnected, chan: nil}}
+  end
+
+  def handle_call(:channel, _from, %{chan: chan} = status) do
+    {:reply, chan, status}
+  end
+
+  def handle_info(:connect, %{status: :disconnected} = state) do
+    case ITKQueue.ConnectionPool.with_connection(&Channel.open/1) do
+      {:ok, chan} ->
+        Process.monitor(chan.pid)
+        Logger.info("#{inspect(self())} Channel opened for publishing")
+        {:noreply, %{state | chan: chan, status: :connected}}
+
+      {:error, reason} ->
+        Logger.error(
+          "#{inspect(self())} Channel failed to open for publishing: #{inspect(reason)}"
+        )
+
+        Process.send_after(self(), :connect, @reconnect_interval)
+        {:noreply, %{state | chan: nil, status: :disconnected}}
+    end
+  end
+
+  def handle_info({:DOWN, _ref, :process, _pid, reason}, state) do
+    Logger.error("Channel closed, because #{inspect(reason)}")
+    Process.send_after(self(), :connect, @reconnect_interval)
+    {:noreply, %{state | status: :disconnected}}
+  end
+
+  def terminate(reason, %{chan: chan, status: :connected}) do
+    Logger.info("#{inspect(self())} Closing channel, because #{inspect(reason)}")
+    Channel.close(chan)
+
+    :ok
+  catch
+    _, _ -> :ok
+  end
+
+  def terminate(_reason, _state), do: :ok
+end

--- a/lib/itk/queue/publisher.ex
+++ b/lib/itk/queue/publisher.ex
@@ -3,7 +3,7 @@ require Logger
 defmodule ITKQueue.Publisher do
   @moduledoc false
 
-  alias ITKQueue.{PublisherPool, Fallback, Headers}
+  alias ITKQueue.{Fallback, Headers, PublisherPool}
 
   @doc """
   Publishes one or multiple messages to the given routing key.

--- a/lib/itk/queue/publisher.ex
+++ b/lib/itk/queue/publisher.ex
@@ -3,38 +3,15 @@ require Logger
 defmodule ITKQueue.Publisher do
   @moduledoc false
 
-  alias ITKQueue.{Channel, ConnectionPool, Fallback, Headers}
+  alias ITKQueue.{PublisherPool, Fallback, Headers}
 
   @doc """
-  Publishes a message to the given routing key.
-
-  If a connection is provided it will be used. Otherwise a connection
-  will be retrieved from the connection pool, used, and returned.
-
-  If you will be publishing several messages in a short period of time
-  checking out a single connection to use for all of your publishing will
-  be more efficient.
+  Publishes one or multiple messages to the given routing key.
   """
   @spec publish(routing_key :: String.t(), messages :: map | list(map), options :: Keyword.t()) ::
           :ok
   def publish(routing_key, messages, options) when is_bitstring(routing_key) do
     publish(routing_key, messages, [], options)
-  end
-
-  @spec publish(
-          AMQP.Connection.t() | AMQP.Channel.t(),
-          routing_key :: String.t(),
-          messages :: map | list(map),
-          options :: Keyword.t()
-        ) :: :ok
-  def publish(connection = %AMQP.Connection{}, routing_key, messages, options)
-      when is_bitstring(routing_key) do
-    publish(connection, routing_key, messages, [], options)
-  end
-
-  def publish(channel = %AMQP.Channel{}, routing_key, messages, options)
-      when is_bitstring(routing_key) do
-    publish(channel, routing_key, messages, [], options)
   end
 
   @spec publish(
@@ -49,20 +26,24 @@ defmodule ITKQueue.Publisher do
       fake_publish(routing_key, messages)
     else
       try do
-        {wait_diff, {ref, connection}} = time(fn -> ConnectionPool.checkout() end)
+        {wait_time, {ref, channel}} = time(fn -> PublisherPool.checkout() end)
 
         try do
-          {diff, _} =
+          {pub_time, _} =
             time(fn ->
-              publish_messages(connection, routing_key, messages, headers, options)
+              messages
+              |> List.wrap()
+              |> Enum.each(fn message ->
+                basic_pub(channel, routing_key, message, headers, options)
+              end)
             end)
 
           Logger.info(
-            "Published `#{routing_key}` in #{diff} (waited #{wait_diff})",
+            "Published `#{routing_key}` in #{pub_time} (waited #{wait_time})",
             routing_key: routing_key
           )
         after
-          ConnectionPool.checkin(ref)
+          PublisherPool.checkin(ref)
         end
       catch
         :exit, _reason ->
@@ -78,107 +59,14 @@ defmodule ITKQueue.Publisher do
     end
   end
 
-  @spec publish(
-          AMQP.Connection.t() | AMQP.Channel.t(),
-          routing_key :: String.t(),
-          messages :: map | list(map),
-          headers :: Headers.t(),
-          options :: Keyword.t()
-        ) :: :ok
-  def publish(connection = %AMQP.Connection{}, routing_key, messages, headers, options)
-      when is_bitstring(routing_key) do
-    if testing?() do
-      fake_publish(routing_key, messages)
-    else
-      {diff, _} =
-        time(fn ->
-          publish_messages(connection, routing_key, messages, headers, options)
-        end)
-
-      Logger.info("Published `#{routing_key}` in #{diff}", routing_key: routing_key)
-    end
-
-    :ok
-  end
-
-  def publish(channel = %AMQP.Channel{}, routing_key, messages, headers, options)
-      when is_bitstring(routing_key) do
-    if testing?() do
-      fake_publish(routing_key, messages)
-    else
-      {diff, _} =
-        time(fn ->
-          publish_messages(channel, routing_key, messages, headers, options)
-        end)
-
-      Logger.info("Published `#{routing_key}` in #{diff}", routing_key: routing_key)
-    end
-
-    :ok
-  end
-
-  @spec publish_async(
-          routing_key :: String.t(),
-          messages :: map | list(map),
-          headers :: Headers.t(),
-          stacktrace :: any,
-          options :: Keyword.t()
-        ) :: pid()
-  def publish_async(routing_key, messages, headers, stacktrace, options)
-      when is_bitstring(routing_key) do
-    if testing?() do
-      fake_publish(routing_key, messages)
-      :ok
-    else
-      spawn(fn ->
-        {ref, connection} = ConnectionPool.checkout()
-        publish(connection, routing_key, messages, options)
-        ConnectionPool.checkin(ref)
-      end)
-    end
-  end
-
-  @spec publish_messages(
-          AMQP.Connection.t() | AMQP.Channel.t(),
-          routing_key :: String.t(),
-          messages :: map | list(map),
-          headers :: Headers.t(),
-          options :: Keyword.t()
-        ) :: :ok
-  defp publish_messages(
-         connection = %AMQP.Connection{},
-         routing_key,
-         messages,
-         headers,
-         options
-       ) do
-    channel = Channel.open(connection)
-    publish_messages(channel, routing_key, messages, headers, options)
-    Channel.close(channel)
-  end
-
-  defp publish_messages(
-         channel = %AMQP.Channel{},
-         routing_key,
-         messages,
-         headers,
-         options
-       ) do
-    messages
-    |> List.wrap()
-    |> Enum.each(fn message ->
-      publish_message(channel, routing_key, message, headers, options)
-    end)
-  end
-
-  @spec publish_message(
+  @spec basic_pub(
           AMQP.Channel.t(),
           routing_key :: String.t(),
-          messages :: map | list(map),
+          messages :: map,
           headers :: Headers.t(),
           options :: Keyword.t()
         ) :: :ok
-  defp publish_message(
+  defp basic_pub(
          channel = %AMQP.Channel{},
          routing_key,
          message,

--- a/lib/itk/queue/publisher_pool.ex
+++ b/lib/itk/queue/publisher_pool.ex
@@ -15,16 +15,12 @@ defmodule ITKQueue.PublisherPool do
     pool_opts = [
       name: {:local, @pool_name},
       worker_module: ITKQueue.PubChannel,
-      size: 2,
-      max_overflow: 2
+      size: pool_size(),
+      max_overflow: max_overflow()
     ]
 
     children = [
-      :poolboy.child_spec(@pool_name, pool_opts,
-        amqp_url: ITKQueue.amqp_url(),
-        heartbeat: ITKQueue.heartbeat(),
-        reconnect: true
-      )
+      :poolboy.child_spec(@pool_name, pool_opts)
     ]
 
     supervise(children, strategy: :one_for_one, name: __MODULE__)
@@ -77,5 +73,13 @@ defmodule ITKQueue.PublisherPool do
 
   defp running_library_tests? do
     Application.get_env(:itk_queue, :running_library_tests, false)
+  end
+
+  defp pool_size do
+    Application.get_env(:itk_queue, :pub_pool_size, 20)
+  end
+
+  def max_overflow do
+    Application.get_env(:itk_queue, :max_overflow, pool_size() * 3)
   end
 end

--- a/lib/itk/queue/publisher_pool.ex
+++ b/lib/itk/queue/publisher_pool.ex
@@ -1,0 +1,81 @@
+defmodule ITKQueue.PublisherPool do
+  @moduledoc """
+  Supervises the pool of channels for publishing
+  """
+  use Supervisor
+
+  @pool_name :amqp_pub_pool
+
+  def start_link(arg) do
+    Supervisor.start_link(__MODULE__, arg)
+  end
+
+  @spec init(term) :: no_return
+  def init(_arg) do
+    pool_opts = [
+      name: {:local, @pool_name},
+      worker_module: ITKQueue.PubChannel,
+      size: 2,
+      max_overflow: 2
+    ]
+
+    children = [
+      :poolboy.child_spec(@pool_name, pool_opts,
+        amqp_url: ITKQueue.amqp_url(),
+        heartbeat: ITKQueue.heartbeat(),
+        reconnect: true
+      )
+    ]
+
+    supervise(children, strategy: :one_for_one, name: __MODULE__)
+  end
+
+  @doc """
+  Provides a new channel from the pool.
+
+  Example:
+    ITKQueue.PublisherPool.with_channel(fn(channel) ->
+      # ... do something with the channel
+    end)
+  """
+  def with_channel(action) do
+    :poolboy.transaction(@pool_name, fn pid ->
+      channel = GenServer.call(pid, :channel)
+      action.(channel)
+    end)
+  end
+
+  @doc """
+  Retrieves a connection from the pool.
+
+  You are responsible for returning this connection to the pool when you
+  are done with it.
+
+  Example:
+    {ref, connection} = ITKQueue.PublisherPool.checkout
+    # ... do something with the connection
+    ITKQueue.PublisherPool.checkin(ref)
+  """
+  def checkout do
+    if Application.get_env(:itk_queue, :env) == :test && !running_library_tests?() do
+      {self(), %AMQP.Channel{}}
+    else
+      pid = :poolboy.checkout(@pool_name)
+      channel = GenServer.call(pid, :channel)
+      {pid, channel}
+    end
+  end
+
+  @doc """
+  Return a connection to the pool.
+  """
+  def checkin(pid) do
+    unless Application.get_env(:itk_queue, :env) == :test && !running_library_tests?() do
+      :poolboy.checkin(@pool_name, pid)
+    end
+  end
+
+  defp running_library_tests? do
+    Application.get_env(:itk_queue, :running_library_tests, false)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ITKQueue.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/inside-track/itk_queue"
-  @version "0.10.15"
+  @version "0.11.0"
 
   def project do
     [


### PR DESCRIPTION
Maintain a (small ?) pool of open channels dedicated for publishing. The publisher channels are opened at startup using connections from ConnectionPool, once channel is opened the connection is returned to the pool. If a connection disconnects then the associated channel also breaks, in this case publisher channel automatically tries to re-open a channel as if it was starting up.

Opening channel is the biggest bottleneck when publishing, by avoiding this step we will significantly speed up publishing. In addition you can publish multiple messages at a time if application level logic allows.