### PR TITLE
Handle consumer subscription error

### DIFF
--- a/lib/itk/queue/consumer.ex
+++ b/lib/itk/queue/consumer.ex
@@ -93,6 +93,20 @@ defmodule ITKQueue.Consumer do
       {:error, :connection_lost}
   end
 
+  defp open_channel(connection, queue_name, routing_key) do
+    channel =
+      connection
+      |> Channel.open()
+      |> Channel.bind(queue_name, routing_key)
+
+    Process.monitor(channel.pid)
+
+    {:ok, _} = AMQP.Basic.consume(channel, queue_name, self())
+    {:ok, channel}
+  rescue
+    e -> e
+  end
+
   defp subscribe(subscription = %Subscription{queue_name: queue_name, routing_key: routing_key}) do
     Logger.info(
       "Subscribing to #{queue_name} (#{routing_key})",
@@ -100,34 +114,14 @@ defmodule ITKQueue.Consumer do
       routing_key: routing_key
     )
 
-    case connection() do
-      {:ok, connection} ->
-        try do
-          channel =
-            connection
-            |> Channel.open()
-            |> Channel.bind(queue_name, routing_key)
-
-          Process.monitor(channel.pid)
-
-          {:ok, _} = AMQP.Basic.consume(channel, queue_name, self())
-          %__MODULE__{channel: channel, subscription: subscription}
-        rescue
-          e ->
-            # Subscribe could timeout
-            Logger.error(
-              "Subscribe error: #{inspect(e)}",
-              queue_name: queue_name,
-              routing_key: routing_key
-            )
-
-            Process.send_after(self(), :subscribe, @reconnect_interval)
-            %__MODULE__{subscription: subscription}
-        end
-
-      _ ->
+    with {:ok, conn} <- connection(),
+         {:ok, channel} <- open_channel(conn, queue_name, routing_key) do
+      %__MODULE__{channel: channel, subscription: subscription}
+    else
+      e ->
+        # Subscribe could timeout, or no connection
         Logger.error(
-          "Subscribe error: cannot get connection",
+          "Subscribe error: #{inspect(e)}",
           queue_name: queue_name,
           routing_key: routing_key
         )


### PR DESCRIPTION
In TUD this was causing duplicate consumers to be started after subscribe times out, and because consumer performs subscribe inside init/1, when subscribe fails it brings down the Consumer GenServer