### PR TITLE
Ignore invalid JSON payload

### DIFF
--- a/lib/itk/queue/publisher.ex
+++ b/lib/itk/queue/publisher.ex
@@ -93,7 +93,10 @@ defmodule ITKQueue.Publisher do
            publish_options
          ) do
       :ok ->
-        Logger.info("Publishing #{payload}", routing_key: routing_key)
+        Logger.info("Publishing #{payload}",
+          routing_key: routing_key,
+          message_id: message_uuid(message)
+        )
 
       _ ->
         Logger.info(

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ITKQueue.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/inside-track/itk_queue"
-  @version "0.11.1"
+  @version "0.11.2"
 
   def project do
     [


### PR DESCRIPTION
There is currently a malformed JSON message stuck in one of the queues in production. This library should be capable of ignoring bad messages.