### PR TITLE
Add publisher confirm with retry

### DIFF
--- a/lib/itk/queue.ex
+++ b/lib/itk/queue.ex
@@ -37,6 +37,10 @@ defmodule ITKQueue do
       ITKQueue.ConnectionPool,
       ITKQueue.PublisherPool,
       %{
+        id: ITKQueue.RetryPublisher,
+        start: {ITKQueue.RetryPublisher, :start_link, [[], ITKQueue.RetryPublisher]}
+      },
+      %{
         id: ITKQueue.ConsumerConnection,
         start:
           {ITKQueue.Connection, :start_link,

--- a/lib/itk/queue/channel.ex
+++ b/lib/itk/queue/channel.ex
@@ -20,6 +20,24 @@ defmodule ITKQueue.Channel do
   end
 
   @doc """
+  Opens a topic channel on the given connection, and activate confirm.
+
+  Returns an `AMQP.Channel`.
+  """
+  @spec open_for_publish(connection :: AMQP.Connection.t(), handler :: pid()) :: AMQP.Channel.t()
+  def open_for_publish(connection, handler) do
+    if testing?() do
+      %AMQP.Channel{}
+    else
+      {:ok, channel} = AMQP.Channel.open(connection)
+      AMQP.Exchange.topic(channel, default_exchange())
+      :ok = AMQP.Confirm.select(channel)
+      AMQP.Confirm.register_handler(channel, handler)
+      channel
+    end
+  end
+
+  @doc """
   Closes a channel.
   """
   @spec close(channel :: AMQP.Channel.t()) :: :ok

--- a/test/itk/retry_publisher_test.exs
+++ b/test/itk/retry_publisher_test.exs
@@ -1,0 +1,19 @@
+defmodule ITKQueue.RetryPublisher.Test do
+  use ExUnit.Case
+  alias ITKQueue.RetryPublisher
+
+  test "handles retry message" do
+    {:ok, pid} = ITKQueue.RetryPublisher.start_link([])
+
+    s = :sys.get_state(pid)
+    assert s.last_seq == 0
+
+    GenServer.call(pid, {:retry, [{"test", "my.queue", "foo", "{}", []}]})
+    s = :sys.get_state(pid)
+    assert s.pending != %{}
+
+    send(pid, {:basic_ack, s.last_seq, false})
+    s = :sys.get_state(pid)
+    assert s.pending == %{}
+  end
+end


### PR DESCRIPTION
In order to confirm publishes, a sequence number must be obtained from the
publishing channel before calling basic.publish. This sequence number is given
to PubChannel along with parameters that allow republishing message.

I removed error handling to basic.publish because if we can get next_publish_seqno
then basic.publish must succeed since they both call amqp_channel.

PubChannel is updated to asynchronously confirm published messages. In exceptional
cases where it gets basic.nack, failed messages are handed off to RetryPublisher
to republish.

I measured the time to batch publish 1000 messages locally, it takes about 0.5s. The time to publish a single message is around 1ms.