### PR TITLE
Fix get application name

### DIFF
--- a/lib/itk/queue.ex
+++ b/lib/itk/queue.ex
@@ -13,6 +13,8 @@ defmodule ITKQueue do
   def start(_type, _args) do
     opts = [strategy: :rest_for_one, name: ITKQueue.Supervisor]
 
+    Publisher.configure_metadata()
+
     environment()
     |> children
     |> Supervisor.start_link(opts)


### PR DESCRIPTION
Mix.Project.get is very slow.

I tested `:application.which_applications()` inside running app and it returns the correct value. Also tested inside mix task and it works too.