### PR TITLE
Catch all errors and exceptions with catch/2

### DIFF
--- a/lib/itk/queue/consumer.ex
+++ b/lib/itk/queue/consumer.ex
@@ -171,10 +171,10 @@ defmodule ITKQueue.Consumer do
 
         consume_message(message, channel, meta, subscription)
       end
-    rescue
-      e ->
+    catch
+      kind, e ->
         Logger.error(
-          "Queue error #{Exception.format(:error, e, System.stacktrace())}",
+          "Queue error #{Exception.format(kind, e, System.stacktrace())}",
           message_id: message_uuid(message),
           queue_name: queue_name,
           routing_key: routing_key


### PR DESCRIPTION
Occasionally rabbitmq message get stuck in unacked state when consumer runs into certain errors that `rescue` doesn't handle. Changing to `catch/2` to handle all errors including throw/catch/exit.