### PR TITLE
Normalize caught error

### DIFF
--- a/lib/itk/queue/consumer.ex
+++ b/lib/itk/queue/consumer.ex
@@ -180,6 +180,7 @@ defmodule ITKQueue.Consumer do
           routing_key: routing_key
         )
 
+        e = Exception.normalize(:error, e)
         retry_or_die(message, channel, meta, subscription, e)
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ITKQueue.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/inside-track/itk_queue"
-  @version "0.11.7"
+  @version "0.11.8"
 
   def project do
     [


### PR DESCRIPTION
In addition to raise/error, we can catch throw/exit but we will format them as error.

Here is a table to illustrate https://stackoverflow.com/a/49524869