### PR TITLE
Use spawn_link to start consumer worker

### DIFF
--- a/lib/itk/queue/consumer.ex
+++ b/lib/itk/queue/consumer.ex
@@ -136,7 +136,9 @@ defmodule ITKQueue.Consumer do
   end
 
   defp consume_async(channel, meta, payload, subscription) do
-    spawn(fn ->
+    # Link spawned worker to this process, so that when this GenServer terminates,
+    # the linked worker also shuts down
+    spawn_link(fn ->
       case parse_payload(payload) do
         {:ok, msg} ->
           consume(channel, meta, msg, subscription)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ITKQueue.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/inside-track/itk_queue"
-  @version "0.11.8"
+  @version "0.11.9"
 
   def project do
     [


### PR DESCRIPTION
Link spawned worker to consumer GenServer so that when consumer terminates at shutdown, the linked worker receives exit message to shut down.