### PR TITLE
[BE-33] Handle retry error

### DIFF
--- a/lib/itk/queue/retry.ex
+++ b/lib/itk/queue/retry.ex
@@ -21,7 +21,7 @@ defmodule ITKQueue.Retry do
           subscription :: Subscription.t(),
           message :: ITKQueue.message(),
           meta :: ITKQueue.metadata()
-        ) :: no_return
+        ) :: :ok | no_return
   def delay(channel, %Subscription{queue_name: queue_name, routing_key: routing_key}, message, %{
         headers: headers
       })


### PR DESCRIPTION
We cannot assume retry will always succeed, this is causing us to lose messages on production when elixir app is being shut down.
In case retry fails, send nack with requeue=true so rabbitmq puts the message back.
If this nack fails, then rabbitmq is smart enough to put message back when connection is closed.